### PR TITLE
Fix new product form references

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -3180,7 +3180,7 @@ const AdminSpace = () => {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <form id="new-product-form" className="space-y-4">
+                    <form id="sales-report-form" className="space-y-4">
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <Label>Date de début</Label>
@@ -3852,7 +3852,7 @@ const AdminSpace = () => {
               Ajouter un nouveau produit au catalogue
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          <form id="new-product-form" className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label>Code Article</Label>
@@ -4015,14 +4015,16 @@ const AdminSpace = () => {
               </div>
             </div>
             <div className="flex gap-2">
-              <Button
-                variant="outline"
-                onClick={() => setShowNewProduct(false)}
-                className="flex-1"
-              >
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setShowNewProduct(false)}
+                  className="flex-1"
+                >
                 Annuler
               </Button>
               <Button
+                type="button"
                 className="flex-1 bg-[#805050] hover:bg-[#704040] text-white"
                 onClick={async () => {
                   try {
@@ -4152,7 +4154,7 @@ const AdminSpace = () => {
                 Ajouter
               </Button>
             </div>
-          </div>
+          </form>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- update the sales report form id to `sales-report-form`
- wrap the new product dialog fields in `<form id="new-product-form">`
- ensure the "Ajouter" button still gathers data from `#new-product-form`
- prevent form submission in the dialog buttons

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6886815ddd4c832b94c36177f144b67b